### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
@@ -12,7 +12,8 @@
     "flatpickr": "^4.5.1",
     "nouislider": "^11.1.0",
     "register-service-worker": "^1.5.2",
-    "vue": "2.6.6",
+    "sass": "^1.77.7",
+    "vue": "2.7.0",
     "vue-flatpickr-component": "^8.1.1",
     "vue-lazyload": "^1.2.6",
     "vue-router": "^3.0.2",
@@ -23,7 +24,6 @@
     "@vue/cli-plugin-eslint": "^3.4.0",
     "@vue/cli-plugin-pwa": "^3.4.0",
     "@vue/cli-service": "^3.4.0",
-    "node-sass": "4.11.0",
     "sass-loader": "7.1.0",
     "vue-template-compiler": "2.6.6"
   }


### PR DESCRIPTION
移除了 node-sass，并使用sass替换，企图获得兼容性优势（事实证明，这真的有效）
更新了vue版本：vue-flatpickr-component 的版本为 8.1.8，它需要 vue 版本 ^2.7.0 在scripts中增加build项："NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build"，用以解决高版本node(v17+)引入OpenSSL3导致的旧加密算法不再受支持的问题（其实是某人懒得换低版本的node）